### PR TITLE
Add mutable_content Message option

### DIFF
--- a/gcm.go
+++ b/gcm.go
@@ -22,6 +22,7 @@ type HTTPMessage struct {
 	CollapseKey           string        `json:"collapse_key,omitempty"`
 	Priority              string        `json:"priority,omitempty"`
 	ContentAvailable      bool          `json:"content_available,omitempty"`
+	MutableContent        bool          `json:"mutable_content,omitempty"`
 	TimeToLive            *uint         `json:"time_to_live,omitempty"`
 	RestrictedPackageName string        `json:"restricted_package_name,omitempty"`
 	DryRun                bool          `json:"dry_run,omitempty"`
@@ -57,6 +58,7 @@ type XMPPMessage struct {
 	CollapseKey              string        `json:"collapse_key,omitempty"`
 	Priority                 string        `json:"priority,omitempty"`
 	ContentAvailable         bool          `json:"content_available,omitempty"`
+	MutableContent           bool          `json:"mutable_content,omitempty"`
 	TimeToLive               *uint         `json:"time_to_live,omitempty"`
 	DeliveryReceiptRequested bool          `json:"delivery_receipt_requested,omitempty"`
 	DryRun                   bool          `json:"dry_run,omitempty"`


### PR DESCRIPTION
Required for iOS rich notification support and just general interception of message data on iOS