### PR TITLE
Eliminate race when replacing client where some SendXMPP calls would …

### DIFF
--- a/client.go
+++ b/client.go
@@ -36,12 +36,17 @@ type gcmClient struct {
 	// Clients.
 	xmppClient xmppC
 	httpClient httpC
+
+	// Synchronize replacement of xmppClient through xmppChan
+	xmppChan chan xmppPacket
+
 	// GCM auth.
 	senderID string
 	apiKey   string
 	// XMPP config.
 	pingInterval time.Duration
 	pingTimeout  time.Duration
+	killMonitor  chan bool
 }
 
 // NewClient creates a new GCM client for these credentials.
@@ -99,22 +104,32 @@ func (c *gcmClient) SendHTTP(m HTTPMessage) (*HTTPResponse, error) {
 	return c.httpClient.Send(m)
 }
 
+type xmppResponse struct {
+	MessageID string
+	Bytes     int
+	Err       error
+}
+type xmppPacket struct {
+	m  XMPPMessage
+	rc chan xmppResponse
+}
+
 // SendXMPP sends a message using the XMPP GCM connection server (blocking).
 func (c *gcmClient) SendXMPP(m XMPPMessage) (string, int, error) {
-	c.RLock()
-	defer c.RUnlock()
-	return c.xmppClient.Send(m)
+	rc := make(chan xmppResponse)
+	c.xmppChan <- xmppPacket{m, rc}
+	resp := <-rc
+	return resp.MessageID, resp.Bytes, resp.Err
 }
 
 // Close will stop and close the corresponding client, releasing all resources (blocking).
 func (c *gcmClient) Close() (err error) {
 	c.Lock()
 	defer c.Unlock()
+
+	close(c.killMonitor)
 	if c.xmppClient != nil {
 		err = c.xmppClient.Close(true)
-	}
-	if c.cerr != nil {
-		close(c.cerr)
 	}
 
 	return
@@ -125,6 +140,7 @@ func newGCMClient(xmppc xmppC, httpc httpC, config *Config, h MessageHandler) (*
 	c := &gcmClient{
 		httpClient:   httpc,
 		xmppClient:   xmppc,
+		xmppChan:     make(chan xmppPacket),
 		cerr:         make(chan error, 1),
 		senderID:     config.SenderID,
 		apiKey:       config.APIKey,
@@ -135,6 +151,7 @@ func newGCMClient(xmppc xmppC, httpc httpC, config *Config, h MessageHandler) (*
 		fcm:          config.UseFCM,
 		pingInterval: time.Duration(config.PingInterval) * time.Second,
 		pingTimeout:  time.Duration(config.PingTimeout) * time.Second,
+		killMonitor:  make(chan bool, 1),
 	}
 	if c.pingInterval <= 0 {
 		c.pingInterval = DefaultPingInterval
@@ -144,20 +161,18 @@ func newGCMClient(xmppc xmppC, httpc httpC, config *Config, h MessageHandler) (*
 	}
 
 	clientIsConnected := make(chan bool, 1)
-	killMonitor := make(chan bool, 1)
 	if xmppc != nil {
 		// Create and monitor XMPP client.
-		go c.monitorXMPP(config.MonitorConnection, clientIsConnected, killMonitor)
+		go c.monitorXMPP(config.MonitorConnection, clientIsConnected)
+
 		select {
 		case err := <-c.cerr:
-			killMonitor <- true
-			close(c.cerr)
+			c.killMonitor <- true
 			return nil, err
 		case <-clientIsConnected:
 			return c, nil
 		case <-time.After(10 * time.Second):
-			killMonitor <- true
-			close(c.cerr)
+			c.killMonitor <- true
 			return nil, errors.New("Timed out attempting to connect client")
 		}
 	} else {
@@ -165,109 +180,100 @@ func newGCMClient(xmppc xmppC, httpc httpC, config *Config, h MessageHandler) (*
 	}
 }
 
+func (c *gcmClient) loop(activeMonitor bool) {
+	for {
+		select {
+		case <-c.killMonitor:
+			close(c.cerr)
+			return
+		case packet := <-c.xmppChan:
+			c.RLock()
+			r := xmppResponse{}
+			r.MessageID, r.Bytes, r.Err = c.xmppClient.Send(packet.m)
+			packet.rc <- r
+			c.RUnlock()
+		case err := <-c.cerr:
+			if err == nil {
+				// No error, active close.
+				return
+			}
+
+			log.WithField("xmpp client ref", c.xmppClient.ID()).WithField("error", err).Error("gcm xmpp connection")
+			c.replaceXMPPClient(activeMonitor)
+		}
+	}
+}
+
+// Replace the active client.
+func (c *gcmClient) replaceXMPPClient(activeMonitor bool) {
+	c.Lock()
+	prevc := c.xmppClient
+	close(c.cerr)
+	c.cerr = make(chan error)
+	xmppc, err := connectXMPP(nil, c.sandbox, c.fcm, c.senderID, c.apiKey,
+		c.onCCSMessage, c.cerr, c.debug, c.omitRetry)
+	if err != nil {
+		log.WithFields(log.Fields{"sender id": c.senderID, "error": err}).
+			Error("connect gcm xmpp client")
+		// Wait and try again.
+		// TODO: remove infinite loop.
+		time.Sleep(c.pingTimeout)
+		c.Unlock()
+		c.replaceXMPPClient(activeMonitor)
+	} else {
+		c.xmppClient = xmppc
+		// Close the previous client
+		go prevc.Close(true)
+
+		c.Unlock()
+
+		log.WithField("xmpp client ref", xmppc.ID()).WithField("previous xmpp client ref", prevc.ID()).
+			Warn("gcm xmpp client replaced")
+
+		if activeMonitor {
+			c.spinUpActiveMonitor()
+		}
+	}
+}
+
+func (c *gcmClient) spinUpActiveMonitor() {
+	go func(xc xmppC, ce chan<- error) {
+		// pingPeriodically is blocking.
+		perr := pingPeriodically(xc, c.pingTimeout, c.pingInterval)
+		if !xc.IsClosed() {
+			ce <- perr
+		}
+	}(c.xmppClient, c.cerr)
+	log.WithField("xmpp client ref", c.xmppClient.ID()).Debug("gcm xmpp connection monitoring started")
+}
+
 // monitorXMPP creates a new GCM XMPP client (if not provided), replaces the active client,
 // closes the old client and starts monitoring the new connection.
-func (c *gcmClient) monitorXMPP(activeMonitor bool, clientIsConnected chan bool, killMonitor chan bool) {
-	firstRun := true
-	for {
-		var (
-			xc   xmppC
-			cerr chan error
-		)
-
-		// On the first run, use the provided client and error channel.
-		if firstRun {
-			cerr = c.cerr
-			xc = c.xmppClient
-		} else {
-			xc = nil
-			cerr = make(chan error)
-		}
-
-		// If we've been asked to kill the monitor (ie cerr happened during first run and was returned to caller), don't
-		// loop around anymore. This is what the "on the first run, error exits the monitor" code above is supposed to
-		// handle, but doesn't in edge cases because of concurrency
-		select {
-		case <-killMonitor:
-			return
-		default:
-		}
-
-		// Create XMPP client.
-		log.WithField("sender id", c.senderID).Debug("creating gcm xmpp client")
-		xmppc, err := connectXMPP(xc, c.sandbox, c.fcm, c.senderID, c.apiKey,
-			c.onCCSMessage, cerr, c.debug, c.omitRetry)
-		if err != nil {
-			if firstRun {
-				// On the first run, error exits the monitor.
-				break
-			}
-			log.WithFields(log.Fields{"sender id": c.senderID, "error": err}).
-				Error("connect gcm xmpp client")
-			// Otherwise wait and try again.
-			// TODO: remove infinite loop.
-			time.Sleep(c.pingTimeout)
-			continue
-		}
-		l := log.WithField("xmpp client ref", xmppc.ID())
-
-		// New GCM XMPP client created and connected.
-		if firstRun {
-			l.Info("gcm xmpp client created")
-			firstRun = false
-
-			// Wait just a tick to ensure Listen got called - without this there's probably an edge-case where if the
-			// threading happens exactly wrong you can create a client, return it, and push out a send before you start
-			// listening for its response and therefore you miss the response.  Given network latency that would probably
-			// not ever happen but just to be paranoid... this also ensures that the tests (which assert that Listen got
-			// called) reliably pass.
-			time.Sleep(time.Millisecond)
-			clientIsConnected <- true
-		} else {
-			// Replace the active client.
-			c.Lock()
-			prevc := c.xmppClient
-			prevcerr := c.cerr
-			c.xmppClient = xmppc
-			c.cerr = cerr
-			c.Unlock()
-			l.WithField("previous xmpp client ref", prevc.ID()).
-				Warn("gcm xmpp client replaced")
-
-			// Close the previous client - and the cerr channel, unless killMonitor handled it
-			go func() {
-				prevc.Close(true)
-				select {
-				case <-killMonitor:
-					return
-				default:
-					close(prevcerr)
-				}
-			}()
-		}
-
-		// If active monitoring is enabled, start pinging routine.
-		if activeMonitor {
-			go func(xc xmppC, ce chan<- error) {
-				// pingPeriodically is blocking.
-				perr := pingPeriodically(xc, c.pingTimeout, c.pingInterval)
-				if !xc.IsClosed() {
-					ce <- perr
-				}
-			}(xmppc, cerr)
-			l.Debug("gcm xmpp connection monitoring started")
-		}
-
-		// Wait for an error to occur (from listen, ping or upstream control).
-		if err = <-cerr; err == nil {
-			// No error, active close.
-			break
-		}
-
-		l.WithField("error", err).Error("gcm xmpp connection")
+func (c *gcmClient) monitorXMPP(activeMonitor bool, clientIsConnected chan bool) {
+	// Create XMPP client.
+	log.WithField("sender id", c.senderID).Debug("creating gcm xmpp client")
+	xmppc, err := connectXMPP(c.xmppClient, c.sandbox, c.fcm, c.senderID, c.apiKey,
+		c.onCCSMessage, c.cerr, c.debug, c.omitRetry)
+	if err != nil {
+		// On initial connection, error exits the monitor.
+		return
 	}
-	log.WithField("sender id", c.senderID).
-		Debug("gcm xmpp connection monitor finished")
+	log.WithField("xmpp client ref", xmppc.ID()).Info("gcm xmpp client created")
+
+	// If active monitoring is enabled, start pinging routine.
+	if activeMonitor {
+		c.spinUpActiveMonitor()
+	}
+
+	go c.loop(activeMonitor)
+
+	// Wait just a tick to ensure Listen got called - without this there's probably an edge-case where if the
+	// threading happens exactly wrong you can create a client, return it, and push out a send before you start
+	// listening for its response and therefore you miss the response.  Given network latency that would probably
+	// not ever happen but just to be paranoid... this also ensures that the tests (which assert that Listen got
+	// called) reliably pass.
+	time.Sleep(time.Millisecond)
+	clientIsConnected <- true
 }
 
 // CCS upstream message callback.

--- a/client.go
+++ b/client.go
@@ -37,7 +37,7 @@ type gcmClient struct {
 	xmppClient xmppC
 	httpClient httpC
 
-	// Synchronize replacement of xmppClient through xmppChan
+	// Synchronize sending xmpp with the replacement of xmppClient through xmppChan
 	xmppChan chan xmppPacket
 
 	// GCM auth.


### PR DESCRIPTION
…still send to the old, bad client, and so never receive a response