### PR TITLE
Make HTTP use interoperable FCM endpoints

### DIFF
--- a/http.go
+++ b/http.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	httpAddress = "https://gcm-http.googleapis.com/gcm/send"
+	httpAddress = "https://fcm.googleapis.com/fcm/send"
 )
 
 // httpClient is an interface to stub the internal http.Client.


### PR DESCRIPTION
With FCM becoming the new default, the GCM endpoint will cease to exist. However, the new FCM endpoint is interoperable with legacy and new api keys. This should be a harmless change.